### PR TITLE
Fix tablet and phone layout bug

### DIFF
--- a/phones.scss
+++ b/phones.scss
@@ -168,7 +168,7 @@ and (min-width:0px) and
     }
 
     .locationPane {
-        margin-top: 33px;
+        margin-top: 44px;
     }
 
     /* breadcrumbs menu for phones */

--- a/tablets.scss
+++ b/tablets.scss
@@ -879,7 +879,7 @@ and (max-width:1024px) {
 
     .locationPane { 
         width: 100% ;
-        margin-top: 33px;
+        margin-top: 44px;
     }
 
     .navigationPane {
@@ -1090,10 +1090,6 @@ and (max-width:1024px) {
     .localViewToggle ul li {
         width: 100%;
         float: left;
-    }
-
-    .localViewToggle ul li a {
-        width: 100%;
     }
 
     div.resourcePickerContainer div.localViewToggle {


### PR DESCRIPTION
At certain widths, the `.localViewToggle` menu layout is broken.